### PR TITLE
SPI fix, new begin command and allow oneshotmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Example of initialization
 
 ```C++
 MCP2515 mcp2515(10);
-mcp2515.reset();
+mcp2515.begin();
 mcp2515.setBitrate(CAN_125KBPS);
 mcp2515.setLoopbackMode();
 ```

--- a/examples/CAN_SpeedTest/CAN_SpeedTest.ino
+++ b/examples/CAN_SpeedTest/CAN_SpeedTest.ino
@@ -9,9 +9,8 @@ unsigned long oldTime = 0;
  
 void setup() {
   Serial.begin(115200);
-  SPI.begin();
  
-  mcp2515.reset();
+  mcp2515.begin();
   mcp2515.setBitrate(CAN_125KBPS);
   mcp2515.setNormalMode();
  

--- a/examples/CAN_read/CAN_read.ino
+++ b/examples/CAN_read/CAN_read.ino
@@ -7,9 +7,8 @@ MCP2515 mcp2515(10);
 
 void setup() {
   Serial.begin(115200);
-  SPI.begin();
   
-  mcp2515.reset();
+  mcp2515.begin();
   mcp2515.setBitrate(CAN_125KBPS);
   mcp2515.setNormalMode();
   

--- a/examples/CAN_write/CAN_write.ino
+++ b/examples/CAN_write/CAN_write.ino
@@ -32,9 +32,8 @@ void setup() {
   
   while (!Serial);
   Serial.begin(115200);
-  SPI.begin();
   
-  mcp2515.reset();
+  mcp2515.begin();
   mcp2515.setBitrate(CAN_125KBPS);
   mcp2515.setNormalMode();
   

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -13,11 +13,9 @@ const struct MCP2515::RXBn_REGS MCP2515::RXB[N_RXBUFFERS] = {
 
 MCP2515::MCP2515(const uint8_t _CS)
 {
-    SPI.begin();
-
     SPICS = _CS;
     pinMode(SPICS, OUTPUT);
-    endSPI();
+    digitalWrite(SPICS, HIGH);
 }
 
 void MCP2515::startSPI() {
@@ -28,6 +26,12 @@ void MCP2515::startSPI() {
 void MCP2515::endSPI() {
     digitalWrite(SPICS, HIGH);
     SPI.endTransaction();
+}
+
+MCP2515::ERROR MCP2515::begin(void) {
+	SPI.begin();
+	reset();
+	return ERROR_OK; 
 }
 
 MCP2515::ERROR MCP2515::reset(void)
@@ -160,6 +164,11 @@ MCP2515::ERROR MCP2515::setLoopbackMode()
 MCP2515::ERROR MCP2515::setNormalMode()
 {
     return setMode(CANCTRL_REQOP_NORMAL);
+}
+
+MCP2515::ERROR MCP2515::setOneShotMode()
+{
+    return setMode(CANCTRL_REQOP_ONESHOT);
 }
 
 MCP2515::ERROR MCP2515::setMode(const CANCTRL_REQOP_MODE mode)

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -274,7 +274,7 @@ class MCP2515
             CANCTRL_REQOP_LOOPBACK   = 0x40,
             CANCTRL_REQOP_LISTENONLY = 0x60,
             CANCTRL_REQOP_CONFIG     = 0x80,
-            CANCTRL_REQOP_POWERUP    = 0xE0
+            CANCTRL_REQOP_ONESHOT    = 0x08
         };
 
         static const uint8_t CANSTAT_OPMOD = 0xE0;
@@ -458,11 +458,13 @@ class MCP2515
     public:
         MCP2515(const uint8_t _CS);
         ERROR reset(void);
+		ERROR begin(void);
         ERROR setConfigMode();
         ERROR setListenOnlyMode();
         ERROR setSleepMode();
         ERROR setLoopbackMode();
         ERROR setNormalMode();
+		ERROR setOneShotMode();
         ERROR setClkOut(const CAN_CLKOUT divisor);
         ERROR setBitrate(const CAN_SPEED canSpeed);
         ERROR setBitrate(const CAN_SPEED canSpeed, const CAN_CLOCK canClock);


### PR DESCRIPTION
Fixes SPI issues some people were having by moving SPI.begin into a new mcp2515.begin() command.  This also replaces mcp2515.reset() so you can remove 2 lines from the ino and replace with 1 easier one.
Added one shot mode sending enable by replacing a not used CANCTRL_REQOP_POWERUP (that was also incorrect in accordance with the spec sheet and not a mode - just a statment).