### PR TITLE
Fix clock configuration register settings for 16MHz crystal at 50kbps.

### DIFF
--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -326,6 +326,7 @@ MCP2515::ERROR MCP2515::setBitrate(const CAN_SPEED canSpeed, CAN_CLOCK canClock)
             break;
 
             case (CAN_50KBPS):                                              //  50Kbps
+            cfg1 = MCP_16MHz_50kBPS_CFG1;
             cfg2 = MCP_16MHz_50kBPS_CFG2;
             cfg3 = MCP_16MHz_50kBPS_CFG3;
             break;


### PR DESCRIPTION
Happened across this while trying to debug why I couldn't see CAN frames on a 50MHz bus today.