### PR TITLE
Avoid overflow when Can frame DLC is not set correctly

### DIFF
--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -573,6 +573,10 @@ MCP2515::ERROR MCP2515::setFilter(const RXF num, const bool ext, const uint32_t 
 
 MCP2515::ERROR MCP2515::sendMessage(const TXBn txbn, const struct can_frame *frame)
 {
+    if (frame->can_dlc > CAN_MAX_DLEN) {
+        return ERROR_FAILTX;
+    }
+
     const struct TXBn_REGS *txbuf = &TXB[txbn];
 
     uint8_t data[13];


### PR DESCRIPTION
This avoids overflow when CAN frame DLC is not set correctly when calling ```MCP2515::sendMessage(const TXBn txbn, const struct can_frame *frame)```