### PR TITLE
More appropriate return code for sendMessage method

### DIFF
--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -591,6 +591,10 @@ MCP2515::ERROR MCP2515::sendMessage(const TXBn txbn, const struct can_frame *fra
 
     modifyRegister(txbuf->CTRL, TXB_TXREQ, TXB_TXREQ);
 
+    uint8_t ctrl = readRegister(txbuf->CTRL);
+    if ((ctrl & (TXB_ABTF | TXB_MLOA | TXB_TXERR)) != 0) {
+        return ERROR_FAILTX;
+    }
     return ERROR_OK;
 }
 

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -610,7 +610,7 @@ MCP2515::ERROR MCP2515::sendMessage(const struct can_frame *frame)
         }
     }
 
-    return ERROR_FAILTX;
+    return ERROR_ALLTXBUSY;
 }
 
 MCP2515::ERROR MCP2515::readMessage(const RXBn rxbn, struct can_frame *frame)


### PR DESCRIPTION
1. When all three tx buffer are buzy, it is more appropriate to return ```ERROR_ALLTXBUSY``` in ```sendMessage(const struct can_frame *frame)```

2. If ```TXBnCTRL``` indicates message is lost or lost arbitration or bus error, it is more appropriate to consider it as ```ERROR_FAILTX``` in ```MCP2515::sendMessage(const TXBn txbn, const struct can_frame *frame)```