### PR TITLE
Support receiving both standard and extended frames

### DIFF
--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -49,10 +49,14 @@ MCP2515::ERROR MCP2515::reset(void)
 
     setRegister(MCP_CANINTE, CANINTF_RX0IF | CANINTF_RX1IF | CANINTF_ERRIF | CANINTF_MERRF);
 
+    // receives all valid messages using either Standard or Extended Identifiers that
+    // meet filter criteria. RXF0 is applied for RXB0, RXF1 is applied for RXB1
     modifyRegister(MCP_RXB0CTRL,
-                   RXBnCTRL_RXM_MASK | RXB0CTRL_BUKT,
-                   RXBnCTRL_RXM_STDEXT | RXB0CTRL_BUKT);
-    modifyRegister(MCP_RXB1CTRL, RXBnCTRL_RXM_MASK, RXBnCTRL_RXM_STDEXT);
+                   RXBnCTRL_RXM_MASK | RXB0CTRL_BUKT | RXB0CTRL_FILHIT_MASK,
+                   RXBnCTRL_RXM_STDEXT | RXB0CTRL_BUKT | RXB0CTRL_FILHIT);
+    modifyRegister(MCP_RXB1CTRL,
+                   RXBnCTRL_RXM_MASK | RXB1CTRL_FILHIT_MASK,
+                   RXBnCTRL_RXM_STDEXT | RXB1CTRL_FILHIT);
 
     // clear filters and masks
     /*RXF filters[] = {RXF0, RXF1, RXF2, RXF3, RXF4, RXF5};

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -59,9 +59,12 @@ MCP2515::ERROR MCP2515::reset(void)
                    RXBnCTRL_RXM_STDEXT | RXB1CTRL_FILHIT);
 
     // clear filters and masks
-    /*RXF filters[] = {RXF0, RXF1, RXF2, RXF3, RXF4, RXF5};
+    // do not filter any standard frames for RXF0 used by RXB0
+    // do not filter any extended frames for RXF1 used by RXB1
+    RXF filters[] = {RXF0, RXF1, RXF2, RXF3, RXF4, RXF5};
     for (int i=0; i<6; i++) {
-        ERROR result = setFilter(filters[i], true, 0);
+        bool ext = (i == 1);
+        ERROR result = setFilter(filters[i], ext, 0);
         if (result != ERROR_OK) {
             return result;
         }
@@ -73,7 +76,7 @@ MCP2515::ERROR MCP2515::reset(void)
         if (result != ERROR_OK) {
             return result;
         }
-    }*/
+    }
 
     return ERROR_OK;
 }

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -292,6 +292,10 @@ class MCP2515
         static const uint8_t RXBnCTRL_RXM_MASK   = 0x60;
         static const uint8_t RXBnCTRL_RTR        = 0x08;
         static const uint8_t RXB0CTRL_BUKT       = 0x04;
+        static const uint8_t RXB0CTRL_FILHIT_MASK = 0x03;
+        static const uint8_t RXB1CTRL_FILHIT_MASK = 0x07;
+        static const uint8_t RXB0CTRL_FILHIT = 0x00;
+        static const uint8_t RXB1CTRL_FILHIT = 0x01;
 
         static const uint8_t MCP_SIDH = 0;
         static const uint8_t MCP_SIDL = 1;


### PR DESCRIPTION
> The RXM[1:0] bits (RXBnCTRL[6:5]) set special
Receive modes. Normally, these bits are cleared to ‘00’
to enable reception of all valid messages as determined by the appropriate acceptance filters. In this case, the determination of whether or not to receive
standard or extended messages is determined by the
EXIDE bit (RFXnSIDL[3]) in the Filter n Standard Identifier Low register.

As filters/masks are enabled in ```reset```, then filtering of sid and eid are controlled by ```EXIDE``` of ```RXFnSIDL```, as explained in datasheet 4.2.2. By default ```EXIDE``` is ```0```, so extended frames can not be received.

This PR makes MCP2515 able to receive sid and eid at the same time. Specifically, RXF0 is used for RXB0 and RXF1 is used for RXB1. The RXF0 can receive all standard frames and RXF1 can receive all extended frames.

Fixes https://github.com/autowp/arduino-mcp2515/issues/13, https://github.com/autowp/arduino-mcp2515/issues/23