### PR TITLE
Add Arduino.h to make compilation passing in esp32 board

### DIFF
--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -1,3 +1,4 @@
+#include "Arduino.h"
 #include "mcp2515.h"
 
 const struct MCP2515::TXBn_REGS MCP2515::TXB[MCP2515::N_TXBUFFERS] = {


### PR DESCRIPTION
Currently library can not be compiled in esp32 arduino board, this PR fixes this.