### PR TITLE
Support Arduino compilation in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: c
+sudo: false
 
 addons:
-  sonarcloud:
-    organization: "autowp-github"
-    token:
-      secure: $SONARCLOUD_TOKEN
+  apt:
+    sources:
+      - llvm-toolchain-trusty-5.0
+      - key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
 
 script:
-  - sonar-scanner || travis_terminate 1;
+  - build_main_platforms
+  
+before_install:
+  - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
+
+cache:
+  directories:
+    - ~/arduino_ide
+    - ~/.arduino15/packages/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Arduino MCP2515 CAN interface library
 ---------------------------------------------------------
-
+[![Build Status](https://travis-ci.org/autowp/arduino-mcp2515.svg?branch=master)](https://travis-ci.org/autowp/arduino-mcp2515)
 
 <br>
 CAN-BUS is a common industrial bus because of its long travel distance, medium communication speed and high reliability. It is commonly found on modern machine tools and as an automotive diagnostic bus. This CAN-BUS Shield gives your Arduino/Seeeduino CAN-BUS capibility. With an OBD-II converter cable added on and the OBD-II library imported, you are ready to build an onboard diagnostic device or data logger.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,0 @@
-sonar.projectKey=autowp_arduino-mcp2515
-sonar.projectName=WheelsAge Backend
-sonar.projectVersion=1.0
-
-sonar.sources=.
-


### PR DESCRIPTION
It looks like sonarcloud doesn't support arduino linting and compilation, this PR uses https://github.com/adafruit/ci-arduino to compile Arduino library in Travis.