### PR TITLE
Remove additional SPI.begin in examples

### DIFF
--- a/examples/CAN_SpeedTest/CAN_SpeedTest.ino
+++ b/examples/CAN_SpeedTest/CAN_SpeedTest.ino
@@ -9,7 +9,6 @@ unsigned long oldTime = 0;
  
 void setup() {
   Serial.begin(115200);
-  SPI.begin();
  
   mcp2515.reset();
   mcp2515.setBitrate(CAN_125KBPS);
@@ -19,7 +18,6 @@ void setup() {
 }
  
 void loop() {
- 
   if (mcp2515.readMessage(&canMsg) == MCP2515::ERROR_OK) {
     cntr++;
   }
@@ -30,5 +28,4 @@ void loop() {
     Serial.println(" msg/sec");
     cntr = 0;      
   }
- 
 }

--- a/examples/CAN_read/CAN_read.ino
+++ b/examples/CAN_read/CAN_read.ino
@@ -7,7 +7,6 @@ MCP2515 mcp2515(10);
 
 void setup() {
   Serial.begin(115200);
-  SPI.begin();
   
   mcp2515.reset();
   mcp2515.setBitrate(CAN_125KBPS);
@@ -18,22 +17,17 @@ void setup() {
 }
 
 void loop() {
-  
   if (mcp2515.readMessage(&canMsg) == MCP2515::ERROR_OK) {
-      
     Serial.print(canMsg.can_id, HEX); // print ID
     Serial.print(" "); 
     Serial.print(canMsg.can_dlc, HEX); // print DLC
     Serial.print(" ");
     
     for (int i = 0; i<canMsg.can_dlc; i++)  {  // print the data
-        
       Serial.print(canMsg.data[i],HEX);
       Serial.print(" ");
-
     }
 
     Serial.println();      
   }
-
 }

--- a/examples/CAN_write/CAN_write.ino
+++ b/examples/CAN_write/CAN_write.ino
@@ -7,7 +7,6 @@ MCP2515 mcp2515(10);
 
 
 void setup() {
-
   canMsg1.can_id  = 0x0F6;
   canMsg1.can_dlc = 8;
   canMsg1.data[0] = 0x8E;
@@ -32,7 +31,6 @@ void setup() {
   
   while (!Serial);
   Serial.begin(115200);
-  SPI.begin();
   
   mcp2515.reset();
   mcp2515.setBitrate(CAN_125KBPS);
@@ -42,12 +40,10 @@ void setup() {
 }
 
 void loop() {
-  
   mcp2515.sendMessage(&canMsg1);
   mcp2515.sendMessage(&canMsg2);
 
   Serial.println("Messages sent");
   
   delay(100);
-
 }


### PR DESCRIPTION
Since SPI module is required for MCP2515 driver, and it is initialized in ```MCP2515::MCP2515```, there is no need to declare ```SPI.begin``` explicitly. This PR fixes this.