### PR TITLE
Correct interrupt example: Varbiable accessed by ISR needs to be volatile

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ void loop() {
 Example of interrupt based read
 
 ```C++
-bool interrupt = false;
+volatile bool interrupt = false;
 struct can_frame frame;
 
 void irqHandler() {


### PR DESCRIPTION
Global variables accessed by an ISR need to be volatile to avoid them being optimized away.