### PR TITLE
Add functions to expose the RX/TX error counters

### DIFF
--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -754,3 +754,13 @@ void MCP2515::clearERRIF()
     //clearInterrupts();
     modifyRegister(MCP_CANINTF, CANINTF_ERRIF, 0);
 }
+
+uint8_t MCP2515::errorCountRX(void)                             
+{
+    return readRegister(MCP_REC);
+}
+
+uint8_t MCP2515::errorCountTX(void)                             
+{
+    return readRegister(MCP_TEC);
+}

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -488,6 +488,8 @@ class MCP2515
         void clearRXnOVR(void);
         void clearMERR();
         void clearERRIF();
+        uint8_t errorCountRX(void);
+        uint8_t errorCountTX(void);
 };
 
 #endif


### PR DESCRIPTION
This exposes the REC and TEC registers. They hold the error counters and can give insides before the checkError triggers.

See Figure 6-1 in the MCP2515 Datasheet how they work with : 
![grafik](https://user-images.githubusercontent.com/1591573/120884883-1cb97c00-c5e6-11eb-8308-c8e311ccae81.png)

https://ww1.microchip.com/downloads/en/DeviceDoc/MCP2515-Stand-Alone-CAN-Controller-with-SPI-20001801J.pdf