### PR TITLE
Added support for One-Shot Mode (OSM)

### DIFF
--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -172,6 +172,9 @@ MCP2515::ERROR MCP2515::setNormalMode()
 
 MCP2515::ERROR MCP2515::setMode(const CANCTRL_REQOP_MODE mode)
 {
+    // Check for oneshot mode.
+    mode = osmFlag ? mode | CANCTRL_OSM : mode & ~(CANCTRL_OSM);
+
     modifyRegister(MCP_CANCTRL, CANCTRL_REQOP, mode);
 
     unsigned long endTime = millis() + 10;
@@ -763,4 +766,12 @@ uint8_t MCP2515::errorCountRX(void)
 uint8_t MCP2515::errorCountTX(void)                             
 {
     return readRegister(MCP_TEC);
+}
+
+void MCP2515::enableOSM(void) {
+    osmFlag = true;
+}
+
+void MCP2515::disableOSM(void) {
+    osmFlag = false;
 }

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -443,6 +443,7 @@ class MCP2515
         } RXB[N_RXBUFFERS];
 
         uint8_t SPICS;
+        bool osmFlag = false;
 
     private:
 
@@ -490,6 +491,10 @@ class MCP2515
         void clearERRIF();
         uint8_t errorCountRX(void);
         uint8_t errorCountTX(void);
+
+        // ONE SHOT MODE
+        void enableOSM(void);
+        void disableOSM(void);
 };
 
 #endif


### PR DESCRIPTION
Just added the support for One-Shot Mode.

Simple usage is to call the `"enableOSM"` or `"disableOSM"` member function before configuring the mode of operation.

Let me know if any optimization is needed or could be done in a better way.
