### PR TITLE
Allow SPI Peripheral Customization

### DIFF
--- a/mcp2515.h
+++ b/mcp2515.h
@@ -444,6 +444,7 @@ class MCP2515
 
         uint8_t SPICS;
         uint32_t SPI_CLOCK;
+        SPIClass * SPIn;
 
     private:
 
@@ -461,7 +462,7 @@ class MCP2515
         void prepareId(uint8_t *buffer, const bool ext, const uint32_t id);
     
     public:
-        MCP2515(const uint8_t _CS, const uint32_t _SPI_CLOCK = DEFAULT_SPI_CLOCK);
+        MCP2515(const uint8_t _CS, const uint32_t _SPI_CLOCK = DEFAULT_SPI_CLOCK, SPIClass * _SPI = nullptr);
         ERROR reset(void);
         ERROR setConfigMode();
         ERROR setListenOnlyMode();


### PR DESCRIPTION
MCP2515 constructor now has an optional SPIClass pointer as its last parameter to allow selecting a different SPI peripheral.

Fully backward compatible. All the code that works so far will continue to work correctly without any changes.

- If no argument is passed during construction, the Arduino default "SPI" will be used and initialized with begin().

- If a SPIClass to use is specified, then it is the library user's responsibility to initialize that SPI ( other_spi.begin()) with the proper settings outside of the library (I.E. in void setup()). In this way, one can use different SPI pins in boards that support it (ESP32, some STM32). Thanks to @morcibacsi and @FStefanni for the suggestions.

Tested on ESP32 HSPI and VSPI with default and custom pins. It should also work with all boards featuring multiple SPI peripherals (SPI1, SPI2, etc.).

This PR should close #53 - #54.