### PR TITLE
PR #46 opened on Sep 12, 2020 by jxltom, + add "clearReceiveBufferFull"

### DIFF
--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -671,8 +671,6 @@ MCP2515::ERROR MCP2515::readMessage(const RXBn rxbn, struct can_frame *frame)
 
     readRegisters(rxb->DATA, frame->data, dlc);
 
-    modifyRegister(MCP_CANINTF, rxb->CANINTF_RXnIF, 0);
-
     return ERROR_OK;
 }
 
@@ -681,10 +679,14 @@ MCP2515::ERROR MCP2515::readMessage(struct can_frame *frame)
     ERROR rc;
     uint8_t stat = getStatus();
 
-    if ( stat & STAT_RX0IF ) {
+    if ( stat & STAT_RX0IF && mcp2515_rx_index == 0 ) {
         rc = readMessage(RXB0, frame);
+        if ( stat & STAT_RX1IF ) mcp2515_rx_index = 1;
+        modifyRegister(MCP_CANINTF, RXB[RXB0].CANINTF_RXnIF, 0);
     } else if ( stat & STAT_RX1IF ) {
-        rc = readMessage(RXB1, frame);
+        rc = readMessage( RXB1, frame );
+        mcp2515_rx_index = 0;
+        modifyRegister(MCP_CANINTF, RXB[RXB1].CANINTF_RXnIF, 0);
     } else {
         rc = ERROR_NOMSG;
     }

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -730,6 +730,11 @@ uint8_t MCP2515::getInterrupts(void)
     return readRegister(MCP_CANINTF);
 }
 
+void MCP2515::clearReceiveBufferFull(void)
+{
+    setRegister(MCP_BFPCTRL, 0);
+}
+
 void MCP2515::clearInterrupts(void)
 {
     setRegister(MCP_CANINTF, 0);

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -361,6 +361,7 @@ class MCP2515
             MCP_RXF2SIDL = 0x09,
             MCP_RXF2EID8 = 0x0A,
             MCP_RXF2EID0 = 0x0B,
+        MCP_BFPCTRL = 0x0C, // RXnBF PIN CONTROL AND STATUS
             MCP_CANSTAT  = 0x0E,
             MCP_CANCTRL  = 0x0F,
             MCP_RXF3SIDH = 0x10,
@@ -487,6 +488,7 @@ class MCP2515
         bool checkError(void);
         uint8_t getErrorFlags(void);
         void clearRXnOVRFlags(void);
+    void clearReceiveBufferFull(void);
         uint8_t getInterrupts(void);
         uint8_t getInterruptMask(void);
         void clearInterrupts(void);

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -449,6 +449,7 @@ class MCP2515
         uint8_t SPICS;
         uint32_t SPI_CLOCK;
         SPIClass * SPIn;
+        uint8_t mcp2515_rx_index = 0;
 
     private:
 


### PR DESCRIPTION
Just a version working for me with ATMEGA, MCP2515, isolated CAN Bus (Cf. https://github.com/autowp/arduino-mcp2515/issues/119#issuecomment-2929246983)
- PR #46 opened on Sep 12, 2020 by jxltom
- add method "clearReceiveBufferFull"