### PR TITLE
Issue 122 - Update can.h

### DIFF
--- a/can.h
+++ b/can.h
@@ -39,7 +39,7 @@ typedef __u32 canid_t;
 struct can_frame {
     canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
     __u8    can_dlc; /* frame payload length in byte (0 .. CAN_MAX_DLEN) */
-    __u8    data[CAN_MAX_DLEN] __attribute__((aligned(8)));
+    __u8    data[CAN_MAX_DLEN] alignas(8);
 };
 
 #endif /* CAN_H_ */


### PR DESCRIPTION
Changed the GCC-specific `__attribute__` to the more cross-compiler `alignas`.
