### PR TITLE
refactored One Shot Mode functionality

### DIFF
--- a/can.h
+++ b/can.h
@@ -37,9 +37,9 @@ typedef __u32 canid_t;
 #define CAN_MAX_DLEN 8
 
 struct can_frame {
-    canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
-    __u8    can_dlc; /* frame payload length in byte (0 .. CAN_MAX_DLEN) */
-    __u8    data[CAN_MAX_DLEN] __attribute__((aligned(8)));
+               canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
+               __u8    can_dlc; /* frame payload length in byte (0 .. CAN_MAX_DLEN) */
+    alignas(8) __u8    data[CAN_MAX_DLEN];
 };
 
 #endif /* CAN_H_ */

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -26,6 +26,7 @@ MCP2515::MCP2515(const uint8_t _CS, const uint32_t _SPI_CLOCK, SPIClass * _SPI)
     SPI_CLOCK = _SPI_CLOCK;
     pinMode(SPICS, OUTPUT);
     digitalWrite(SPICS, HIGH);
+    OSMflag = false;
 }
 
 void MCP2515::startSPI() {
@@ -179,7 +180,7 @@ MCP2515::ERROR MCP2515::setNormalMode()
 
 MCP2515::ERROR MCP2515::setMode(const CANCTRL_REQOP_MODE mode)
 {
-    modifyRegister(MCP_CANCTRL, CANCTRL_REQOP, mode);
+    modifyRegister(MCP_CANCTRL, CANCTRL_REQOP | CANCTRL_OSM, OSMflag ? mode | CANCTRL_OSM : mode & ~(CANCTRL_OSM));
 
     unsigned long endTime = millis() + 10;
     bool modeMatch = false;
@@ -776,4 +777,14 @@ uint8_t MCP2515::errorCountRX(void)
 uint8_t MCP2515::errorCountTX(void)                             
 {
     return readRegister(MCP_TEC);
+}
+
+// these merely set the OSM flag
+// setMode(...) or the other setXxxxMode() i.e: setNormalMode() must be called afterwards to set the correct mode with OSM
+void MCP2515::enableOSM(void) {
+    OSMflag = true;
+}
+
+void MCP2515::disableOSM(void) {
+    OSMflag = false;
 }

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -26,7 +26,6 @@ MCP2515::MCP2515(const uint8_t _CS, const uint32_t _SPI_CLOCK, SPIClass * _SPI)
     SPI_CLOCK = _SPI_CLOCK;
     pinMode(SPICS, OUTPUT);
     digitalWrite(SPICS, HIGH);
-    OSMflag = false;
 }
 
 void MCP2515::startSPI() {
@@ -178,9 +177,14 @@ MCP2515::ERROR MCP2515::setNormalMode()
     return setMode(CANCTRL_REQOP_NORMAL);
 }
 
+MCP2515::ERROR MCP2515::setNormalOneShotMode()
+{
+    return setMode(CANCTRL_REQOP_NORMAL | CANCTRL_OSM);
+}
+
 MCP2515::ERROR MCP2515::setMode(const CANCTRL_REQOP_MODE mode)
 {
-    modifyRegister(MCP_CANCTRL, CANCTRL_REQOP | CANCTRL_OSM, OSMflag ? mode | CANCTRL_OSM : mode & ~(CANCTRL_OSM));
+    modifyRegister(MCP_CANCTRL, CANCTRL_REQOP | CANCTRL_OSM, mode);
 
     unsigned long endTime = millis() + 10;
     bool modeMatch = false;
@@ -777,14 +781,4 @@ uint8_t MCP2515::errorCountRX(void)
 uint8_t MCP2515::errorCountTX(void)                             
 {
     return readRegister(MCP_TEC);
-}
-
-// these merely set the OSM flag
-// setMode(...) or the other setXxxxMode() i.e: setNormalMode() must be called afterwards to set the correct mode with OSM
-void MCP2515::enableOSM(void) {
-    OSMflag = true;
-}
-
-void MCP2515::disableOSM(void) {
-    OSMflag = false;
 }

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -449,7 +449,6 @@ class MCP2515
         uint8_t SPICS;
         uint32_t SPI_CLOCK;
         SPIClass * SPIn;
-        bool OSMflag;
 
     private:
 
@@ -474,6 +473,7 @@ class MCP2515
         ERROR setSleepMode();
         ERROR setLoopbackMode();
         ERROR setNormalMode();
+		ERROR setNormalOneShotMode();
         ERROR setClkOut(const CAN_CLKOUT divisor);
         ERROR setBitrate(const CAN_SPEED canSpeed);
         ERROR setBitrate(const CAN_SPEED canSpeed, const CAN_CLOCK canClock);
@@ -497,8 +497,6 @@ class MCP2515
         void clearERRIF();
         uint8_t errorCountRX(void);
         uint8_t errorCountTX(void);
-        void enableOSM(void);
-        void disableOSM(void);
 };
 
 #endif

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -449,6 +449,7 @@ class MCP2515
         uint8_t SPICS;
         uint32_t SPI_CLOCK;
         SPIClass * SPIn;
+        bool OSMflag;
 
     private:
 
@@ -496,6 +497,8 @@ class MCP2515
         void clearERRIF();
         uint8_t errorCountRX(void);
         uint8_t errorCountTX(void);
+        void enableOSM(void);
+        void disableOSM(void);
 };
 
 #endif


### PR DESCRIPTION
Prior to this pull request, a node in Normal mode that sends a message will continuously send the same message over and over until another node in Normal mode appears on the bus and acknowledges receipt of this message.

With this pull request, if one calls .setNormalOneShotMode(); the 2515 is placed in One Shot Mode and a message will be sent only once regardless of if there is anybody else on the bus to acknowledge it as would be the case if all the other nodes in the bus are in ListenOnlyMode.

This PR merges the code from @DeltaC6 and the insight from @igorok107 on the correct mask to use to make it work
https://github.com/DeltaC6/arduino-mcp2515/tree/master
https://github.com/autowp/arduino-mcp2515/pull/65#issuecomment-1236624113


This pull request refactors the code introduced in [PR#124](https://github.com/autowp/arduino-mcp2515/pull/124)

This code has been verified on the ArduinoEnigma CanBusTool
https://arduinoenigma.blogspot.com/2024/12/can-bus-tool.html