### PR TITLE
refactored One Shot Mode functionality and added CANCTRL_REQOP_OSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ To create connection with MCP2515 provide pin number where SPI CS is connected (
 
 The available modes are listed as follows:
 ```C++
-mcp2515.setNormalMode();
-mcp2515.setLoopbackMode();
-mcp2515.setListenOnlyMode();
+mcp2515.setNormalMode(); // sends and receives data normally, sends acknowledgments to other nodes, when sending data, requires an acknowledgment from another node that the message was received or else, the 2515 will autonomously keep sending the same data
+mcp2515.setNormalOneShotMode(); // sends and receives data normally, sends acknoledgements to other nodes that their message was received, when sending data, does not require an acknowledgement from another node that the message was received.
+mcp2515.setLoopbackMode(); // data sent is immediately received and is not written to the bus, does not send acknowledgements
+mcp2515.setListenOnlyMode(); // does not send data, only receives data, does not send acknowledgements
 ```
 The available baudrates are listed as follows:
 ```C++

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=autowp-mcp2515
-version=1.2.1
+version=1.3.1
 author=autowp <autowp@gmail.com>
 maintainer=autowp <autowp@gmail.com>
 sentence=Arduino MCP2515 CAN interface library

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -177,9 +177,14 @@ MCP2515::ERROR MCP2515::setNormalMode()
     return setMode(CANCTRL_REQOP_NORMAL);
 }
 
+MCP2515::ERROR MCP2515::setNormalOneShotMode()
+{
+    return setMode(CANCTRL_REQOP_OSM);
+}
+
 MCP2515::ERROR MCP2515::setMode(const CANCTRL_REQOP_MODE mode)
 {
-    modifyRegister(MCP_CANCTRL, CANCTRL_REQOP, mode);
+    modifyRegister(MCP_CANCTRL, CANCTRL_REQOP | CANCTRL_OSM, mode);
 
     unsigned long endTime = millis() + 10;
     bool modeMatch = false;

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -274,6 +274,7 @@ class MCP2515
 
         enum /*class*/ CANCTRL_REQOP_MODE : uint8_t {
             CANCTRL_REQOP_NORMAL     = 0x00,
+            CANCTRL_REQOP_OSM        = 0x08,
             CANCTRL_REQOP_SLEEP      = 0x20,
             CANCTRL_REQOP_LOOPBACK   = 0x40,
             CANCTRL_REQOP_LISTENONLY = 0x60,
@@ -473,6 +474,7 @@ class MCP2515
         ERROR setSleepMode();
         ERROR setLoopbackMode();
         ERROR setNormalMode();
+        ERROR setNormalOneShotMode();
         ERROR setClkOut(const CAN_CLKOUT divisor);
         ERROR setBitrate(const CAN_SPEED canSpeed);
         ERROR setBitrate(const CAN_SPEED canSpeed, const CAN_CLOCK canClock);


### PR DESCRIPTION
This PR brings this library from version 1.2.1 to 1.3.1

It adds setNormalOneShotMode(), a form of Normal Mode in which the 2515 only sends a message once without requiring acknowledgements from another node in Normal Mode in the same bus as would be the case if all the other nodes in the bus are in ListenOnlyMode.

This PR merges the code from @DeltaC6 and the insight from @igorok107 on the correct mask to use to make it work
https://github.com/DeltaC6/arduino-mcp2515/tree/master
https://github.com/autowp/arduino-mcp2515/pull/65#issuecomment-1236624113

This code has been verified on the ArduinoEnigma CanBusTool
https://arduinoenigma.blogspot.com/2024/12/can-bus-tool.html 

PR History:

Initial PR using flags and set/reset functions
https://github.com/autowp/arduino-mcp2515/pull/124

This PR refactored code and created a single method setNormalOneShotMode() but gave compilation errors on some platforms
https://github.com/autowp/arduino-mcp2515/pull/128 

Compiles cleanly but all changes to library show up as different commits
https://github.com/autowp/arduino-mcp2515/pull/130
