### PR TITLE
updated can.h to have arduino specific can_frame 3 bytes smaller than can_frame structure used by other compilers

### DIFF
--- a/can.h
+++ b/can.h
@@ -36,10 +36,18 @@ typedef __u32 canid_t;
 #define CAN_MAX_DLC 8
 #define CAN_MAX_DLEN 8
 
+#if defined(Arduino_h)
+struct can_frame {
+               canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
+               __u8    can_dlc; /* frame payload length in byte (0 .. CAN_MAX_DLEN) */
+			   __u8    data[CAN_MAX_DLEN];
+};
+#else
 struct can_frame {
                canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
                __u8    can_dlc; /* frame payload length in byte (0 .. CAN_MAX_DLEN) */
     alignas(8) __u8    data[CAN_MAX_DLEN];
 };
+#endif
 
 #endif /* CAN_H_ */


### PR DESCRIPTION
can_frame was changed in Pull Request (https://github.com/autowp/arduino-mcp2515/issues/122) to accommodate other compilers by adding alignas(8) to __u8    data[CAN_MAX_DLEN];

When compiling in Arduino, this adds 3 extra bytes of ram per each can_frame struct used.

This pull request detects if the arduino headers are used and then defines an arduino specific version 

```
#if defined(Arduino_h)
struct can_frame {
               canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
               __u8    can_dlc; /* frame payload length in byte (0 .. CAN_MAX_DLEN) */
			   __u8    data[CAN_MAX_DLEN];
};
#else
struct can_frame {
               canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
               __u8    can_dlc; /* frame payload length in byte (0 .. CAN_MAX_DLEN) */
    alignas(8) __u8    data[CAN_MAX_DLEN];
};
#endif
```

**With alignas(8):**

Serial.println(sizeof(can_frame));
16 

Sketch uses 22854 bytes (74%) of program storage space. Maximum is 30720 bytes.
Global variables use 1800 bytes (87%) of dynamic memory, leaving 248 bytes for local variables. Maximum is 2048 bytes.

**Without alignas(8):**

Serial.println(sizeof(can_frame));
13 

Sketch uses 22864 bytes (74%) of program storage space. Maximum is 30720 bytes.
Global variables use 1688 bytes (82%) of dynamic memory, leaving 360 bytes for local variables. Maximum is 2048 bytes.