### PR TITLE
Add extra error definitions to better differentiate message transmiss…

### DIFF
--- a/mcp2515.h
+++ b/mcp2515.h
@@ -210,12 +210,15 @@ class MCP2515
 {
     public:
         enum ERROR {
-            ERROR_OK        = 0,
-            ERROR_FAIL      = 1,
-            ERROR_ALLTXBUSY = 2,
-            ERROR_FAILINIT  = 3,
-            ERROR_FAILTX    = 4,
-            ERROR_NOMSG     = 5
+            ERROR_OK          = 0,
+            ERROR_FAIL        = 1,
+            ERROR_ALLTXBUSY   = 2,
+            ERROR_FAILINIT    = 3,
+            ERROR_FAILTX      = 4,
+            ERROR_FAILTX_MLOA = 5,
+            ERROR_FAILTX_ABTF = 6,
+            ERROR_NOMSG       = 7,
+            ERROR_INVALID_DLC = 8
         };
 
         enum MASK {


### PR DESCRIPTION
Add extra error definitions to better differentiate message transmission error reason.

This way user can better understand the reason behind a message transmission error.