### PR TITLE
Add getter for CTRL register

### DIFF
--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -723,6 +723,11 @@ uint8_t MCP2515::getErrorFlags(void)
     return readRegister(MCP_EFLG);
 }
 
+uint8_t MCP2515::getControlRegister(void) 
+{
+    return readRegister(MCP_CANCTRL);
+}
+
 void MCP2515::clearRXnOVRFlags(void)
 {
 	modifyRegister(MCP_EFLG, EFLG_RX0OVR | EFLG_RX1OVR, 0);

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -487,6 +487,7 @@ class MCP2515
         bool checkReceive(void);
         bool checkError(void);
         uint8_t getErrorFlags(void);
+        uint8_t getControlRegister(void);
         void clearRXnOVRFlags(void);
         uint8_t getInterrupts(void);
         uint8_t getInterruptMask(void);


### PR DESCRIPTION
This way user can check configuration was applied correctly. This proved useful when SPI noise caused misconfiguration of MCP2515 by writing incorrect values into CTRL register.