### PR TITLE
Move hardware initialization out of MCP2515 constructor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/can.h
+++ b/can.h
@@ -37,8 +37,8 @@ typedef __u32 canid_t;
 #define CAN_MAX_DLEN 8
 
 struct can_frame {
-               canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
-               __u8    can_dlc; /* frame payload length in byte (0 .. CAN_MAX_DLEN) */
+    canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
+    __u8    can_dlc; /* frame payload length in byte (0 .. CAN_MAX_DLEN) */
     alignas(8) __u8    data[CAN_MAX_DLEN];
 };
 

--- a/examples/CAN_SpeedTest/CAN_SpeedTest.ino
+++ b/examples/CAN_SpeedTest/CAN_SpeedTest.ino
@@ -10,6 +10,7 @@ unsigned long oldTime = 0;
 void setup() {
   Serial.begin(115200);
  
+  mcp2515.begin();
   mcp2515.reset();
   mcp2515.setBitrate(CAN_125KBPS);
   mcp2515.setNormalMode();

--- a/examples/CAN_read/CAN_read.ino
+++ b/examples/CAN_read/CAN_read.ino
@@ -8,6 +8,7 @@ MCP2515 mcp2515(10);
 void setup() {
   Serial.begin(115200);
   
+  mcp2515.begin();
   mcp2515.reset();
   mcp2515.setBitrate(CAN_125KBPS);
   mcp2515.setNormalMode();

--- a/examples/CAN_write/CAN_write.ino
+++ b/examples/CAN_write/CAN_write.ino
@@ -32,6 +32,7 @@ void setup() {
   while (!Serial);
   Serial.begin(115200);
   
+  mcp2515.begin();
   mcp2515.reset();
   mcp2515.setBitrate(CAN_125KBPS);
   mcp2515.setNormalMode();

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -19,16 +19,28 @@ MCP2515::MCP2515(const uint8_t _CS, const uint32_t _SPI_CLOCK, SPIClass * _SPI)
     }
     else {
         SPIn = &SPI;
-        SPIn->begin();
     }
 
     SPICS = _CS;
     SPI_CLOCK = _SPI_CLOCK;
+    spiInitialized = false;
+}
+
+void MCP2515::begin() {
+    if (spiInitialized) {
+        return;  // Already initialized
+    }
     pinMode(SPICS, OUTPUT);
     digitalWrite(SPICS, HIGH);
+    SPIn->begin();
+    spiInitialized = true;
 }
 
 void MCP2515::startSPI() {
+    // Backward compatibility with code not calling begin() explicitly
+    if (!spiInitialized) {
+        begin();
+    }
     SPIn->beginTransaction(SPISettings(SPI_CLOCK, MSBFIRST, SPI_MODE0));
     digitalWrite(SPICS, LOW);
 }

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -450,6 +450,7 @@ class MCP2515
         uint8_t SPICS;
         uint32_t SPI_CLOCK;
         SPIClass * SPIn;
+        bool spiInitialized;
 
     private:
 
@@ -468,6 +469,7 @@ class MCP2515
     
     public:
         MCP2515(const uint8_t _CS, const uint32_t _SPI_CLOCK = DEFAULT_SPI_CLOCK, SPIClass * _SPI = nullptr);
+        void begin();
         ERROR reset(void);
         ERROR setConfigMode();
         ERROR setListenOnlyMode();


### PR DESCRIPTION
## Problem
The `MCP2515` constructor calls `SPI.begin()`, `pinMode()`, and `digitalWrite()` directly. For global/static instances, the constructor runs before `main()`/`setup()` — before the Arduino core and hardware are fully ready. This can cause hangs or incorrect peripheral configuration.

## Solution
Added a `begin()` method that performs all hardware initialization:
- `pinMode(SPICS, OUTPUT)`
- `digitalWrite(SPICS, HIGH)`
- `SPIn->begin()`

The constructor now only stores the CS pin, SPI pointer, and clock — no hardware access.

## Backward compatibility
Existing code that doesn't explicitly call `begin()` continues to work. The `startSPI()` method checks `spiInitialized` and lazily calls `begin()` on first use, ensuring drop-in compatibility.
Examples have been updated to explicitely call begin().

## Files changed
- `mcp2515.cpp` — moved hardware init to `begin()`, added `spiInitialized` flag with lazy init in `startSPI()`
- `mcp2515.h` — added `begin()` declaration and `spiInitialized` member

## Rationale
Matches standard Arduino library pattern (`Wire.begin()`, `Serial.begin()`, etc.) where hardware init always happens in a `begin()` method, never in the constructor.
