### PR TITLE
Add setBitTiming() method for direct CNF register control

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -502,6 +502,20 @@ MCP2515::ERROR MCP2515::setBitrate(const CAN_SPEED canSpeed, CAN_CLOCK canClock)
     }
 }
 
+MCP2515::ERROR MCP2515::setBitTiming(uint8_t cnf1, uint8_t cnf2, uint8_t cnf3)
+{
+    ERROR error = setConfigMode();
+    if (error != ERROR_OK) {
+        return error;
+    }
+
+    setRegister(MCP_CNF1, cnf1);
+    setRegister(MCP_CNF2, cnf2);
+    setRegister(MCP_CNF3, cnf3);
+
+    return ERROR_OK;
+}
+
 MCP2515::ERROR MCP2515::setClkOut(const CAN_CLKOUT divisor)
 {
     if (divisor == CLKOUT_DISABLE) {

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -478,6 +478,7 @@ class MCP2515
         ERROR setClkOut(const CAN_CLKOUT divisor);
         ERROR setBitrate(const CAN_SPEED canSpeed);
         ERROR setBitrate(const CAN_SPEED canSpeed, const CAN_CLOCK canClock);
+        ERROR setBitTiming(uint8_t cnf1, uint8_t cnf2, uint8_t cnf3);
         ERROR setFilterMask(const MASK num, const bool ext, const uint32_t ulData);
         ERROR setFilter(const RXF num, const bool ext, const uint32_t ulData);
         ERROR sendMessage(const TXBn txbn, const struct can_frame *frame);


### PR DESCRIPTION
## Problem
The existing `setBitrate()` method only accepts `CAN_SPEED`/`CAN_CLOCK` enum pairs. When exact CNF1/CNF2/CNF3 register values are known, there is no way to set them directly through the public API.

## Solution
Added `setBitTiming(uint8_t cnf1, uint8_t cnf2, uint8_t cnf3)` method that sets bit timing registers directly with raw CNF1/CNF2/CNF3 values:

1. Enters config mode (safe to call even if already in config mode)
2. Writes the three timing registers (CNF1, CNF2, CNF3) directly
3. Returns without exiting config mode — this allows batching additional config-mode operations before switching to normal mode

This is useful when the desired timing cannot be expressed as a `CAN_SPEED`/`CAN_CLOCK` pair accepted by `setBitrate()`, for example when matching exact register values produced by other libraries.

## Usage
### Basic usage
```cpp
// Set ACAN2515-compatible timing for 125 kbps @ 16 MHz
mcp2515.setBitTiming(0xC3, 0xE4, 0x04);
mcp2515.setNormalMode();
```

### Batching multiple config operations
```cpp
// Apply custom bit timing, then configure filters/masks in a single config mode session
mcp2515.setBitTiming(0xC3, 0xE4, 0x04);
mcp2515.setFilterMask(MASK0, false, 0x7FF);  // Accept all 11-bit IDs
mcp2515.setFilter(RXF0, false, 0x123);       // Match specific ID 0x123
mcp2515.setNormalMode();                     // Exit config mode once all config is done
```

## API
```cpp
/**
 * Set bit timing registers directly with raw CNF1/CNF2/CNF3 values.
 *
 * Enters config mode, writes the three timing registers, then returns.
 * The caller is responsible for calling setNormalMode() (or another
 * operating mode) afterwards. This allows batching additional config-mode
 * operations (e.g., filters, masks) in a single config mode session.
 *
 * Calling this method when already in config mode is safe, as entering
 * config mode when already active has no effect.
 *
 * @param cnf1  Value for CNF1 register (BRP + SJW)
 * @param cnf2  Value for CNF2 register (BTLMODE + SAM + PS1 + PRSEG)
 * @param cnf3  Value for CNF3 register (SOF + WAKFIL + PS2)
 * @return ERROR_OK on success, ERROR_FAIL if config mode cannot be entered
 */
```

## Files changed
- `mcp2515.cpp` — implemented `setBitTiming()`
- `mcp2515.h` — added declaration
