### PR TITLE
late SPI init for modern micro-controllers that need manual SPI pin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,7 @@ Note: To transfer data on high speed of CAN interface via UART dont forget to up
 Late SPI init for controllers that require manual SPI pin definition
 ```C++
 MCP2515 mcp2515(10,10000000,&SPI,false);
-```
-<br>
 
-Desired SPI interface and transfer speed are set in constructor
-
-```C++
 void setup() {
     SPI.setRX(4);  // MISO (late SPI init)
     SPI.setTX(3);  // MOSI
@@ -151,7 +146,8 @@ void setup() {
 }
 ```
 <br>
-
+Desired SPI interface and transfer speed are set in constructor
+<br>
 SPI config is completed in setup() and SPI.begin() is called. 
 
 ## Frame data format

--- a/README.md
+++ b/README.md
@@ -127,6 +127,32 @@ Default value is MCP_16MHZ
 <br>
 
 Note: To transfer data on high speed of CAN interface via UART dont forget to update UART baudrate as necessary.
+<br>
+
+Late SPI init for controllers that require manual SPI pin definition
+```C++
+MCP2515 mcp2515(10,10000000,&SPI,false);
+```
+<br>
+
+Desired SPI interface and transfer speed are set in constructor
+
+```C++
+void setup() {
+    SPI.setRX(4);  // MISO (late SPI init)
+    SPI.setTX(3);  // MOSI
+    SPI.setSCK(2); // SCK
+    SPI.setCS(10);
+    SPI.begin();
+
+    mcp2515.reset();
+    mcp2515.setBitrate(CAN_500KBPS,MCP_8MHZ);
+    mcp2515.setNormalMode();
+}
+```
+<br>
+
+SPI config is completed in setup() and SPI.begin() is called. 
 
 ## Frame data format
 

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -12,14 +12,15 @@ const struct MCP2515::RXBn_REGS MCP2515::RXB[N_RXBUFFERS] = {
     {MCP_RXB1CTRL, MCP_RXB1SIDH, MCP_RXB1DATA, CANINTF_RX1IF}
 };
 
-MCP2515::MCP2515(const uint8_t _CS, const uint32_t _SPI_CLOCK, SPIClass * _SPI)
+MCP2515::MCP2515(const uint8_t _CS, const uint32_t _SPI_CLOCK, SPIClass * _SPI, bool init)
 {
     if (_SPI != nullptr) {
         SPIn = _SPI;
     }
     else {
         SPIn = &SPI;
-        SPIn->begin();
+        if (init)
+            SPIn->begin();
     }
 
     SPICS = _CS;

--- a/mcp2515.h
+++ b/mcp2515.h
@@ -467,7 +467,7 @@ class MCP2515
         void prepareId(uint8_t *buffer, const bool ext, const uint32_t id);
     
     public:
-        MCP2515(const uint8_t _CS, const uint32_t _SPI_CLOCK = DEFAULT_SPI_CLOCK, SPIClass * _SPI = nullptr);
+        MCP2515(const uint8_t _CS, const uint32_t _SPI_CLOCK = DEFAULT_SPI_CLOCK, SPIClass * _SPI = nullptr, bool init = true);
         ERROR reset(void);
         ERROR setConfigMode();
         ERROR setListenOnlyMode();


### PR DESCRIPTION
In  the current implementation SPI.begin() is called from the constructor, however newer Raspberry Pi and ESP32 controllers support/require mapping of the SPI pins prior to start of the SPI core function.

This PR adds a flag to optionally skip the call to SPI.begin() so it can be called from setup().

This is a sample for such a late init on a RaspberryPi 2040-Zero
```C++
MCP2515 mcp2515(10,10000000,&SPI,false);

void setup() {
    SPI.setRX(4);  // MISO (late SPI init)
    SPI.setTX(3);  // MOSI
    SPI.setSCK(2); // SCK
    SPI.setCS(10);
    SPI.begin();

    mcp2515.reset();
    mcp2515.setBitrate(CAN_500KBPS,MCP_8MHZ);
    mcp2515.setNormalMode();
}
```

Apart from the move to optional  SPI.begin() with a constructor uption this code changes no previous behaviour.
 